### PR TITLE
change some "data" fields to postgres TEXT

### DIFF
--- a/dist/DB.js
+++ b/dist/DB.js
@@ -62,17 +62,17 @@ class Database {
     (0, _classPrivateFieldSet2.default)(this, _Models, {
       idtoken: (0, _classPrivateFieldGet2.default)(this, _sequelize).define('idtoken', {
         iss: {
-          type: Sequelize.STRING,
+          type: Sequelize.TEXT,
           primaryKey: true
         },
         issuer_code: {
-          type: Sequelize.STRING
+          type: Sequelize.TEXT
         },
         user: {
-          type: Sequelize.STRING
+          type: Sequelize.TEXT
         },
         roles: {
-          type: Sequelize.ARRAY(Sequelize.STRING)
+          type: Sequelize.ARRAY(Sequelize.TEXT)
         },
         userInfo: {
           type: Sequelize.JSONB
@@ -89,11 +89,11 @@ class Database {
       }),
       contexttoken: (0, _classPrivateFieldGet2.default)(this, _sequelize).define('contexttoken', {
         path: {
-          type: Sequelize.STRING,
+          type: Sequelize.TEXT,
           primaryKey: true
         },
         user: {
-          type: Sequelize.STRING
+          type: Sequelize.TEXT
         },
         context: {
           type: Sequelize.JSONB
@@ -107,23 +107,23 @@ class Database {
       }),
       platform: (0, _classPrivateFieldGet2.default)(this, _sequelize).define('platform', {
         platformName: {
-          type: Sequelize.STRING
+          type: Sequelize.TEXT
         },
         platformUrl: {
-          type: Sequelize.STRING,
+          type: Sequelize.TEXT,
           primaryKey: true
         },
         clientId: {
-          type: Sequelize.STRING
+          type: Sequelize.TEXT
         },
         authEndpoint: {
-          type: Sequelize.STRING
+          type: Sequelize.TEXT
         },
         accesstokenEndpoint: {
-          type: Sequelize.STRING
+          type: Sequelize.TEXT
         },
         kid: {
-          type: Sequelize.STRING
+          type: Sequelize.TEXT
         },
         authConfig: {
           type: Sequelize.JSONB
@@ -131,43 +131,43 @@ class Database {
       }),
       publickey: (0, _classPrivateFieldGet2.default)(this, _sequelize).define('publickey', {
         kid: {
-          type: Sequelize.STRING,
+          type: Sequelize.TEXT,
           primaryKey: true
         },
         iv: {
-          type: Sequelize.STRING
+          type: Sequelize.TEXT
         },
         data: {
-          type: Sequelize.STRING(10000)
+          type: Sequelize.TEXT
         }
       }),
       privatekey: (0, _classPrivateFieldGet2.default)(this, _sequelize).define('privatekey', {
         kid: {
-          type: Sequelize.STRING,
+          type: Sequelize.TEXT,
           primaryKey: true
         },
         iv: {
-          type: Sequelize.STRING
+          type: Sequelize.TEXT
         },
         data: {
-          type: Sequelize.STRING(10000)
+          type: Sequelize.TEXT
         }
       }),
       accesstoken: (0, _classPrivateFieldGet2.default)(this, _sequelize).define('accesstoken', {
         platformUrl: {
-          type: Sequelize.STRING,
+          type: Sequelize.TEXT,
           primaryKey: true
         },
         iv: {
-          type: Sequelize.STRING
+          type: Sequelize.TEXT
         },
         data: {
-          type: Sequelize.STRING
+          type: Sequelize.TEXT
         }
       }),
       nonce: (0, _classPrivateFieldGet2.default)(this, _sequelize).define('nonce', {
         nonce: {
-          type: Sequelize.STRING,
+          type: Sequelize.TEXT,
           primaryKey: true
         }
       }) // Sync models to database, creating tables if they do not exist

--- a/src/DB.js
+++ b/src/DB.js
@@ -37,17 +37,17 @@ class Database {
     this.#Models = {
       idtoken: this.#sequelize.define('idtoken', {
         iss: {
-          type: Sequelize.STRING,
+          type: Sequelize.TEXT,
           primaryKey: true
         },
         issuer_code: {
-          type: Sequelize.STRING
+          type: Sequelize.TEXT
         },
         user: {
-          type: Sequelize.STRING
+          type: Sequelize.TEXT
         },
         roles: {
-          type: Sequelize.ARRAY(Sequelize.STRING)
+          type: Sequelize.ARRAY(Sequelize.TEXT)
         },
         userInfo: {
           type: Sequelize.JSONB
@@ -64,11 +64,11 @@ class Database {
       }),
       contexttoken: this.#sequelize.define('contexttoken', {
         path: {
-          type: Sequelize.STRING,
+          type: Sequelize.TEXT,
           primaryKey: true
         },
         user: {
-          type: Sequelize.STRING
+          type: Sequelize.TEXT
         },
         context: {
           type: Sequelize.JSONB
@@ -82,23 +82,23 @@ class Database {
       }),
       platform: this.#sequelize.define('platform', {
         platformName: {
-          type: Sequelize.STRING
+          type: Sequelize.TEXT
         },
         platformUrl: {
-          type: Sequelize.STRING,
+          type: Sequelize.TEXT,
           primaryKey: true
         },
         clientId: {
-          type: Sequelize.STRING
+          type: Sequelize.TEXT
         },
         authEndpoint: {
-          type: Sequelize.STRING
+          type: Sequelize.TEXT
         },
         accesstokenEndpoint: {
-          type: Sequelize.STRING
+          type: Sequelize.TEXT
         },
         kid: {
-          type: Sequelize.STRING
+          type: Sequelize.TEXT
         },
         authConfig: {
           type: Sequelize.JSONB
@@ -106,43 +106,43 @@ class Database {
       }),
       publickey: this.#sequelize.define('publickey', {
         kid: {
-          type: Sequelize.STRING,
+          type: Sequelize.TEXT,
           primaryKey: true
         },
         iv: {
-          type: Sequelize.STRING
+          type: Sequelize.TEXT
         },
         data: {
-          type: Sequelize.STRING(10000)
+          type: Sequelize.TEXT
         }
       }),
       privatekey: this.#sequelize.define('privatekey', {
         kid: {
-          type: Sequelize.STRING,
+          type: Sequelize.TEXT,
           primaryKey: true
         },
         iv: {
-          type: Sequelize.STRING
+          type: Sequelize.TEXT
         },
         data: {
-          type: Sequelize.STRING(10000)
+          type: Sequelize.TEXT
         }
       }),
       accesstoken: this.#sequelize.define('accesstoken', {
         platformUrl: {
-          type: Sequelize.STRING,
+          type: Sequelize.TEXT,
           primaryKey: true
         },
         iv: {
-          type: Sequelize.STRING
+          type: Sequelize.TEXT
         },
         data: {
-          type: Sequelize.STRING
+          type: Sequelize.TEXT
         }
       }),
       nonce: this.#sequelize.define('nonce', {
         nonce: {
-          type: Sequelize.STRING,
+          type: Sequelize.TEXT,
           primaryKey: true
         }
       })


### PR DESCRIPTION
when I tried to connect to moodle, sequelize threw some errors about too short fields (data in accesstoken).

this here replaces string by text, which fixes this.

I'm also aware that my other PR didn't build it, and well, this one is in conflict. I can clean this up as one PR... 

(I don't know what the `#...` signs in the source code mean or do, but it built fine and runs)